### PR TITLE
fix(useGsap): simplify cleanup — remove page:transition:finish deferral

### DIFF
--- a/docs/content/2.composables/1.use-gsap.md
+++ b/docs/content/2.composables/1.use-gsap.md
@@ -8,7 +8,7 @@ description: Access the GSAP instance or create a scoped animation context with 
 ## Which form should I use?
 
 - **Zero-argument** — Quick prototyping or when you need full manual control over cleanup. You manage timelines, contexts, and plugin instances yourself.
-- **Context form (recommended)** — For most components. Automatic cleanup, SSR-safe, page-transition aware, and scoped to your element. No boilerplate.
+- **Context form (recommended)** — For most components. Automatic cleanup, SSR-safe, and scoped to your element. No boilerplate.
 
 ## Zero-argument form
 
@@ -52,15 +52,14 @@ onMounted(() => {
 
 ## Context form (recommended)
 
-Pass a `setup` function to wrap your animations in a [`gsap.context()`](https://gsap.com/docs/v3/GSAP/gsap.context/). The context is automatically reverted when the component unmounts or the page transitions away. No cleanup boilerplate needed.
+Pass a `setup` function to wrap your animations in a [`gsap.context()`](https://gsap.com/docs/v3/GSAP/gsap.context/). The context is automatically reverted when the component unmounts. No cleanup boilerplate needed.
 
 ### Advantages
 
 1. **Auto-cleanup** — All tweens, timelines, and plugin instances (ScrollTrigger, Draggable, etc.) are reverted automatically without a single `onUnmounted`.
 2. **SSR-safe** — Returns `{ contextSafe: fn => fn }` on the server, so no DOM access during SSR builds.
-3. **Page-transition aware** — Cleanup is deferred until after the leave transition finishes, so exit animations play smoothly through the fade-out.
-4. **Scoped selectors** — The `scope` option restricts CSS class/id selectors to a subtree, preventing selector leaks to same-class elements in other components.
-5. **Reactive re-runs** — Pass `dependencies` to re-run the setup function when reactive values change, with automatic context revert + re-run.
+3. **Scoped selectors** — The `scope` option restricts CSS class/id selectors to a subtree, preventing selector leaks to same-class elements in other components.
+4. **Reactive re-runs** — Pass `dependencies` to re-run the setup function when reactive values change, with automatic context revert + re-run after `nextTick()`.
 
 ### Before and after
 
@@ -113,19 +112,13 @@ useGsap(() => {
 | `scope` | `Ref<HTMLElement \| null>` | `undefined` | Scopes class/id selectors inside the element |
 | `dependencies` | `WatchSource[]` | `[]` | Re-run `setup` when any source changes |
 | `revertOnUpdate` | `boolean` | `true` | Revert the previous context before re-running |
-| `cleanupOn` | `'unmount' \| 'route-leave'` | `'unmount'` | **Deprecated, no-op.** Both values produce identical behavior. Kept for backward compatibility. |
+| `cleanupOn` | `'unmount' \| 'route-leave'` | `'unmount'` | **Deprecated, no-op.** Cleanup always runs during teardown. Kept for backward compatibility. |
 
 ::note
-**Page transition behavior**
+**Cleanup timing**
 
-When navigating, `useGsap(setup)` defers context cleanup until after the page leave transition
-(`page:transition:finish`). Animations continue playing through the fade-out on every page,
-with no extra configuration required.
-
-The `cleanupOn` option is kept for backward compatibility but is now a no-op — both
-`'unmount'` and `'route-leave'` produce identical behavior.
-
-If navigation is cancelled (a route guard rejects), the context stays alive and no revert happens.
+`useGsap(setup)` reverts its context during component teardown. The deprecated
+`cleanupOn` option is accepted for compatibility, but it does not change runtime behavior.
 ::
 
 ### `contextSafe`
@@ -152,7 +145,8 @@ useGsap(() => {
 }, { dependencies: [color] })
 ```
 
-Every time `color` changes the context reverts and re-runs (controlled by `revertOnUpdate`).
+Every time `color` changes the context reverts and re-runs after Vue flushes the DOM update
+cycle (controlled by `revertOnUpdate`).
 
 ## Using with plugin composables
 

--- a/playground/pages/no-transition.vue
+++ b/playground/pages/no-transition.vue
@@ -48,9 +48,8 @@ const phase = computed(() => {
 })
 
 // pageTransition: false → this page has no transition.
-// willTransition evaluates to false in onBeforeRouteLeave, so
-// the GSAP context is reverted immediately in onUnmounted rather
-// than waiting for page:transition:finish (which would never fire).
+// `useGsap(setup)` still cleans up in `onUnmounted`, so navigating back
+// should restart the animation from a clean context.
 definePageMeta({ pageTransition: false })
 </script>
 
@@ -62,14 +61,13 @@ definePageMeta({ pageTransition: false })
         This page has <code>pageTransition: false</code>.<br>
         Click <em>← Back</em> mid-animation: the page snaps away instantly
         (no transition), then navigate back — the animation should restart
-        from the beginning, confirming the context was cleanly reverted in
-        <code>onUnmounted</code>.<br>
+        from the beginning, confirming the context was cleanly reverted during
+        teardown.<br>
         Compare with
         <NuxtLink
           to="/use-gsap-timeline"
           class="inline-link"
-        >useGsap (timeline)</NuxtLink>
-        where the animation plays <em>through</em> the 1s page-fade.
+        >useGsap (timeline)</NuxtLink>.
       </p>
       <NuxtLink
         to="/"

--- a/playground/pages/page-transition.vue
+++ b/playground/pages/page-transition.vue
@@ -39,8 +39,8 @@ definePageMeta({
 <template>
   <div class="page-container">
     <header>
-      <h1>Page Transition + Cleanup Strategies</h1>
-      <p>Navigate away to see both cleanup strategies in action during the page transition.</p>
+      <h1>Page Transition + Teardown Cleanup</h1>
+      <p>Navigate away to verify that both examples are cleaned up during component teardown.</p>
     </header>
 
     <div class="columns">
@@ -48,10 +48,10 @@ definePageMeta({
         ref="containerA"
         class="column"
       >
-        <h2>cleanupOn: 'route-leave'</h2>
+        <h2>Deprecated `cleanupOn`</h2>
         <p>
-          Reverts via <code>onScopeDispose</code> after the leave transition finishes — boxes keep
-          bouncing <strong>through</strong> the fade-out, then stop when the component unmounts.
+          This example still passes <code>cleanupOn: 'route-leave'</code>, but the option is ignored.
+          Cleanup happens during teardown, just like the default path.
         </p>
         <div class="boxes">
           <div class="box box-a" />
@@ -64,10 +64,10 @@ definePageMeta({
         ref="containerB"
         class="column"
       >
-        <h2>cleanupOn: 'unmount' (default)</h2>
+        <h2>Default behavior</h2>
         <p>
-          Reverts via <code>onScopeDispose</code> — boxes keep bouncing <strong>through</strong> the
-          fade-out, then stop when the component unmounts.
+          The default setup follows the same behavior: the GSAP context is reverted when the
+          component is torn down, with no route-leave hook involved.
         </p>
         <div class="boxes">
           <div class="box box-b" />

--- a/src/runtime/composables/createGsapComposable.ts
+++ b/src/runtime/composables/createGsapComposable.ts
@@ -1,9 +1,6 @@
-import { useNuxtApp } from '#app'
-import { appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 import { gsap } from 'gsap'
 import type { ComputedRef, Ref, WatchSource } from 'vue'
-import { onMounted, onUnmounted, watch } from 'vue'
-import { onBeforeRouteLeave } from 'vue-router'
+import { nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { createGsapComposable } from '../create-gsap-composable'
 
 /**
@@ -22,19 +19,11 @@ export interface UseGsapOptions {
   /**
    * When to revert the GSAP context during page navigation.
    *
-   * @deprecated This option has no behavioral effect. Both `'unmount'` and
-   * `'route-leave'` produce identical behavior: when the leaving page has a
-   * transition defined (per-page `definePageMeta({ pageTransition })` or a
-   * global `app.pageTransition` in `nuxt.config`), the GSAP context is deferred
-   * until `page:transition:finish`; otherwise it reverts immediately in
-   * `onUnmounted`. Kept for backward compatibility only.
-   *
-   * **Note:** if a `router.beforeEach` guard rejects navigation *after*
-   * `onBeforeRouteLeave` fires, `isLeavingViaRoute` is NOT set (the conditional
-   * check for a transition runs in the guard), so the context stays active.
+   * @deprecated This option is ignored and kept only for backward compatibility.
+   * Cleanup always happens during component teardown via `onUnmounted`.
    *
    * @example
-   * // Continuous animation that should play through the page-leave transition
+   * // `cleanupOn` is ignored, but still accepted for compatibility
    * useGsap(() => { ... }, { cleanupOn: 'route-leave' })
    */
   cleanupOn?: 'unmount' | 'route-leave'
@@ -81,29 +70,28 @@ export function useGsap(
   }
 
   let ctx: gsap.Context | null = null
-  let isLeavingViaRoute = false
+  let setupVersion = 0
+  let isUnmounted = false
 
-  const runSetup = () => {
+  const clearContext = () => {
+    ctx?.revert()
+    ctx = null
+  }
+
+  const scheduleSetup = async () => {
+    const version = ++setupVersion
+    await nextTick()
+
+    if (isUnmounted || version !== setupVersion) {
+      return
+    }
+
     const scope = options?.scope?.value ?? undefined
     ctx = gsap.context(setup, scope)
   }
 
-  onBeforeRouteLeave((_to, from) => {
-    const willTransition = from.meta.pageTransition !== false
-      && !!(from.meta.pageTransition ?? defaultPageTransition)
-
-    if (willTransition) {
-      isLeavingViaRoute = true
-      const nuxtApp = useNuxtApp()
-      nuxtApp.hooks.hookOnce('page:transition:finish', () => {
-        ctx?.revert()
-        ctx = null
-      })
-    }
-  })
-
   onMounted(() => {
-    runSetup()
+    void scheduleSetup()
   })
 
   if (options?.dependencies !== undefined) {
@@ -114,18 +102,17 @@ export function useGsap(
       deps,
       () => {
         if (options.revertOnUpdate === false) return
-        ctx?.revert()
-        runSetup()
+        clearContext()
+        void scheduleSetup()
       },
       { flush: 'post' },
     )
   }
 
   onUnmounted(() => {
-    if (!isLeavingViaRoute) {
-      ctx?.revert()
-      ctx = null
-    }
+    isUnmounted = true
+    setupVersion++
+    clearContext()
   })
 
   const contextSafe: ContextSafeFn = <F extends (...args: unknown[]) => void>(fn: F): F => {

--- a/src/runtime/composables/createGsapComposable.ts
+++ b/src/runtime/composables/createGsapComposable.ts
@@ -70,8 +70,7 @@ export function useGsap(
   }
 
   let ctx: gsap.Context | null = null
-  let setupVersion = 0
-  let isUnmounted = false
+  let cancelPending: (() => void) | null = null
 
   const clearContext = () => {
     ctx?.revert()
@@ -79,13 +78,14 @@ export function useGsap(
   }
 
   const scheduleSetup = async () => {
-    const version = ++setupVersion
+    cancelPending?.()
+    let cancelled = false
+    cancelPending = () => { cancelled = true }
+
     await nextTick()
+    if (cancelled) return
 
-    if (isUnmounted || version !== setupVersion) {
-      return
-    }
-
+    cancelPending = null
     const scope = options?.scope?.value ?? undefined
     ctx = gsap.context(setup, scope)
   }
@@ -110,8 +110,7 @@ export function useGsap(
   }
 
   onUnmounted(() => {
-    isUnmounted = true
-    setupVersion++
+    cancelPending?.()
     clearContext()
   })
 

--- a/test/composables.test.ts
+++ b/test/composables.test.ts
@@ -1,38 +1,37 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createGsapComposable } from '../src/runtime/create-gsap-composable'
-
-// Mock #app to avoid Nuxt context requirement in unit tests
-const transitionFinishCallbacks: Array<() => void> = []
 
 vi.mock('#app', () => ({
   useNuxtApp: vi.fn(),
 }))
 
-vi.mock('#build/nuxt.config.mjs', () => ({
-  appPageTransition: null,
-}))
-
-// Intercept Vue lifecycle hooks so they can be triggered manually in tests.
-// This avoids needing @vue/test-utils while keeping tests isolated.
-const mountedCallbacks: Array<() => void> = []
+const mountedCallbacks: Array<() => void | Promise<void>> = []
 const unmountedCallbacks: Array<() => void> = []
-type RouteLeaveCallback = (to: unknown, from: { meta: Record<string, unknown> }) => void
-const routeLeaveCallbacks: RouteLeaveCallback[] = []
-const watchCallbacks: Array<() => void> = []
+const watchCallbacks: Array<() => void | Promise<void>> = []
+const nextTickMock = vi.fn(() => Promise.resolve())
 
 vi.mock('vue', async () => {
   const actual = await vi.importActual<typeof import('vue')>('vue')
   return {
     ...actual,
-    onMounted: vi.fn((cb: () => void) => { mountedCallbacks.push(cb) }),
+    nextTick: nextTickMock,
+    onMounted: vi.fn((cb: () => void | Promise<void>) => { mountedCallbacks.push(cb) }),
     onUnmounted: vi.fn((cb: () => void) => { unmountedCallbacks.push(cb) }),
-    watch: vi.fn((_sources: unknown, cb: () => void) => { watchCallbacks.push(cb) }),
+    watch: vi.fn((_sources: unknown, cb: () => void | Promise<void>) => { watchCallbacks.push(cb) }),
   }
 })
 
 vi.mock('vue-router', () => ({
-  onBeforeRouteLeave: vi.fn((cb: RouteLeaveCallback) => { routeLeaveCallbacks.push(cb) }),
+  onBeforeRouteLeave: vi.fn(),
 }))
+
+const flushMount = async () => {
+  await Promise.all(mountedCallbacks.map(cb => cb()))
+}
+
+const flushWatch = async () => {
+  await Promise.all(watchCallbacks.map(cb => cb()))
+}
 
 describe('createGsapComposable', () => {
   beforeEach(() => {
@@ -62,13 +61,7 @@ describe('createGsapComposable', () => {
   })
 
   it('returns null on the server (SSR guard)', () => {
-    // import.meta.server is false in Vitest's jsdom environment, so we simulate
-    // the SSR path by directly testing the guard condition is present in the
-    // factory. The real guard runs at build-time via Vite's define replacement.
-    // This test documents the expected contract: null on server, plugin on client.
     const useMyPlugin = createGsapComposable('MyPlugin')
-    // In jsdom (client env), it should not return null — it will throw because
-    // nuxtApp.$MyPlugin is not set. This confirms the client path is active.
     expect(() => useMyPlugin()).toThrow()
   })
 
@@ -84,20 +77,19 @@ describe('createGsapComposable', () => {
 })
 
 describe('useGsap', () => {
+  beforeEach(() => {
+    mountedCallbacks.length = 0
+    unmountedCallbacks.length = 0
+    watchCallbacks.length = 0
+    nextTickMock.mockClear()
+    vi.restoreAllMocks()
+  })
+
   it('returns the gsap instance', async () => {
     const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
     const { gsap } = await import('gsap')
 
-    const result = useGsap()
-    expect(result).toBe(gsap)
-  })
-})
-
-describe('useGsap with setup', () => {
-  beforeEach(() => {
-    mountedCallbacks.length = 0
-    unmountedCallbacks.length = 0
-    vi.restoreAllMocks()
+    expect(useGsap()).toBe(gsap)
   })
 
   it('returns { contextSafe } when called with a setup function', async () => {
@@ -116,21 +108,49 @@ describe('useGsap with setup', () => {
     expect(typeof contextSafe).toBe('function')
   })
 
-  it('contextSafe wraps a handler and calls through when ctx is set', async () => {
+  it('does not register onBeforeRouteLeave', async () => {
+    const { onBeforeRouteLeave } = await import('vue-router')
+    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
+
+    useGsap(() => {})
+
+    expect(onBeforeRouteLeave).not.toHaveBeenCalled()
+  })
+
+  it('creates the GSAP context only after nextTick on mount', async () => {
     const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
     const { gsap } = await import('gsap')
 
-    const mockCtx = {
+    const contextSpy = vi.spyOn(gsap, 'context').mockReturnValue({
       add: vi.fn((fn: () => unknown) => fn()),
       revert: vi.fn(),
       kill: vi.fn(),
       data: [],
-    }
-    vi.spyOn(gsap, 'context').mockReturnValue(mockCtx as unknown as gsap.Context)
+    } as unknown as gsap.Context)
+
+    useGsap(() => {})
+
+    expect(contextSpy).not.toHaveBeenCalled()
+
+    await flushMount()
+
+    expect(nextTickMock).toHaveBeenCalledOnce()
+    expect(contextSpy).toHaveBeenCalledOnce()
+  })
+
+  it('contextSafe wraps a handler and calls through when ctx is set', async () => {
+    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
+    const { gsap } = await import('gsap')
+
+    vi.spyOn(gsap, 'context').mockReturnValue({
+      add: vi.fn((fn: () => unknown) => fn()),
+      revert: vi.fn(),
+      kill: vi.fn(),
+      data: [],
+    } as unknown as gsap.Context)
 
     const { contextSafe } = useGsap(() => {})
-    // Simulate onMounted — triggers runSetup() which sets ctx
-    mountedCallbacks.forEach(cb => cb())
+    await flushMount()
 
     const handler = vi.fn().mockReturnValue('ok')
     const safeHandler = contextSafe(handler)
@@ -139,7 +159,7 @@ describe('useGsap with setup', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
-  it('reverts context on unmount', async () => {
+  it('reverts context exactly once on unmount', async () => {
     const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
     const { gsap } = await import('gsap')
 
@@ -152,228 +172,46 @@ describe('useGsap with setup', () => {
     } as unknown as gsap.Context)
 
     useGsap(() => {})
-    // Simulate mount, then dispose
-    mountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).not.toHaveBeenCalled()
+    await flushMount()
 
     unmountedCallbacks.forEach(cb => cb())
+    unmountedCallbacks.forEach(cb => cb())
+
     expect(revertSpy).toHaveBeenCalledOnce()
+  })
+
+  it('does not create a context if unmounted before nextTick resolves', async () => {
+    nextTickMock.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          queueMicrotask(resolve)
+        }),
+    )
+
+    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
+    const { gsap } = await import('gsap')
+
+    const contextSpy = vi.spyOn(gsap, 'context').mockReturnValue({
+      add: vi.fn((fn: () => unknown) => fn()),
+      revert: vi.fn(),
+      kill: vi.fn(),
+      data: [],
+    } as unknown as gsap.Context)
+
+    useGsap(() => {})
+
+    const pendingMount = Promise.all(mountedCallbacks.map(cb => cb()))
+    unmountedCallbacks.forEach(cb => cb())
+    await pendingMount
+
+    expect(contextSpy).not.toHaveBeenCalled()
   })
 
   it('backward compat: useGsap() without args still returns the raw gsap instance', async () => {
     const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
     const { gsap } = await import('gsap')
+
     expect(useGsap()).toBe(gsap)
-  })
-})
-
-describe('useGsap cleanupOn option', () => {
-  beforeEach(() => {
-    mountedCallbacks.length = 0
-    unmountedCallbacks.length = 0
-    routeLeaveCallbacks.length = 0
-    transitionFinishCallbacks.length = 0
-    vi.clearAllMocks()
-  })
-
-  it('registers onBeforeRouteLeave for every useGsap(setup) call', async () => {
-    const { onBeforeRouteLeave } = await import('vue-router')
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-
-    useGsap(() => {})
-
-    expect(onBeforeRouteLeave).toHaveBeenCalledOnce()
-  })
-
-  it('registers onBeforeRouteLeave when cleanupOn is route-leave', async () => {
-    const { useNuxtApp } = await import('#app')
-    const { onBeforeRouteLeave } = await import('vue-router')
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-
-    vi.mocked(useNuxtApp).mockReturnValue({
-      hooks: {
-        hookOnce: vi.fn((event: string, cb: () => void) => {
-          if (event === 'page:transition:finish') {
-            transitionFinishCallbacks.push(cb)
-          }
-          return vi.fn()
-        }),
-      },
-    } as unknown as ReturnType<typeof useNuxtApp>)
-
-    useGsap(() => {}, { cleanupOn: 'route-leave' })
-
-    expect(onBeforeRouteLeave).toHaveBeenCalledOnce()
-  })
-
-  it('reverts context on route leave when cleanupOn is route-leave', async () => {
-    const { useNuxtApp } = await import('#app')
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-    const { gsap } = await import('gsap')
-
-    vi.mocked(useNuxtApp).mockReturnValue({
-      hooks: {
-        hookOnce: vi.fn((event: string, cb: () => void) => {
-          if (event === 'page:transition:finish') {
-            transitionFinishCallbacks.push(cb)
-          }
-          return vi.fn()
-        }),
-      },
-    } as unknown as ReturnType<typeof useNuxtApp>)
-
-    const revertSpy = vi.fn()
-    vi.spyOn(gsap, 'context').mockReturnValue({
-      add: vi.fn((fn: () => unknown) => fn()),
-      revert: revertSpy,
-      kill: vi.fn(),
-      data: [],
-    } as unknown as gsap.Context)
-
-    useGsap(() => {}, { cleanupOn: 'route-leave' })
-    mountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).not.toHaveBeenCalled()
-
-    // Simulate route leave from a page with a transition
-    routeLeaveCallbacks.forEach(cb => cb({}, { meta: { pageTransition: { name: 'page' } } }))
-    // Then simulate the page:transition:finish hook
-    transitionFinishCallbacks.forEach(cb => cb())
-    expect(revertSpy).toHaveBeenCalledOnce()
-  })
-
-  it('default (no cleanupOn): defers revert to page:transition:finish on navigation', async () => {
-    const { useNuxtApp } = await import('#app')
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-    const { gsap } = await import('gsap')
-
-    vi.mocked(useNuxtApp).mockReturnValue({
-      hooks: {
-        hookOnce: vi.fn((event: string, cb: () => void) => {
-          if (event === 'page:transition:finish') {
-            transitionFinishCallbacks.push(cb)
-          }
-          return vi.fn()
-        }),
-      },
-    } as unknown as ReturnType<typeof useNuxtApp>)
-
-    const revertSpy = vi.fn()
-    vi.spyOn(gsap, 'context').mockReturnValue({
-      add: vi.fn((fn: () => unknown) => fn()),
-      revert: revertSpy,
-      kill: vi.fn(),
-      data: [],
-    } as unknown as gsap.Context)
-
-    useGsap(() => {}) // no cleanupOn option
-    mountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).not.toHaveBeenCalled()
-
-    // Leaving a page with a transition → defers to page:transition:finish
-    routeLeaveCallbacks.forEach(cb => cb({}, { meta: { pageTransition: { name: 'page' } } }))
-    transitionFinishCallbacks.forEach(cb => cb())
-    expect(revertSpy).toHaveBeenCalledOnce()
-  })
-
-  it('skips onUnmounted revert when component unmounts during navigation', async () => {
-    const { useNuxtApp } = await import('#app')
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-    const { gsap } = await import('gsap')
-
-    vi.mocked(useNuxtApp).mockReturnValue({
-      hooks: {
-        hookOnce: vi.fn((event: string, cb: () => void) => {
-          if (event === 'page:transition:finish') {
-            transitionFinishCallbacks.push(cb)
-          }
-          return vi.fn()
-        }),
-      },
-    } as unknown as ReturnType<typeof useNuxtApp>)
-
-    const revertSpy = vi.fn()
-    vi.spyOn(gsap, 'context').mockReturnValue({
-      add: vi.fn((fn: () => unknown) => fn()),
-      revert: revertSpy,
-      kill: vi.fn(),
-      data: [],
-    } as unknown as gsap.Context)
-
-    useGsap(() => {})
-    mountedCallbacks.forEach(cb => cb())
-
-    // Simulate route leave from a page with a transition (sets isLeavingViaRoute = true)
-    routeLeaveCallbacks.forEach(cb => cb({}, { meta: { pageTransition: { name: 'page' } } }))
-
-    // Component unmounts (leave transition ended) before transition:finish — revert must NOT fire
-    unmountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).not.toHaveBeenCalled()
-
-    // Transition finishes — revert fires now
-    transitionFinishCallbacks.forEach(cb => cb())
-    expect(revertSpy).toHaveBeenCalledOnce()
-  })
-
-  it('does not double-revert on unmount after page:transition:finish already ran', async () => {
-    const { useNuxtApp } = await import('#app')
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-    const { gsap } = await import('gsap')
-
-    vi.mocked(useNuxtApp).mockReturnValue({
-      hooks: {
-        hookOnce: vi.fn((event: string, cb: () => void) => {
-          if (event === 'page:transition:finish') {
-            transitionFinishCallbacks.push(cb)
-          }
-          return vi.fn()
-        }),
-      },
-    } as unknown as ReturnType<typeof useNuxtApp>)
-
-    const revertSpy = vi.fn()
-    vi.spyOn(gsap, 'context').mockReturnValue({
-      add: vi.fn((fn: () => unknown) => fn()),
-      revert: revertSpy,
-      kill: vi.fn(),
-      data: [],
-    } as unknown as gsap.Context)
-
-    useGsap(() => {}, { cleanupOn: 'route-leave' })
-    mountedCallbacks.forEach(cb => cb())
-
-    // Simulate route leave from a page with a transition, then page:transition:finish (sets ctx to null)
-    routeLeaveCallbacks.forEach(cb => cb({}, { meta: { pageTransition: { name: 'page' } } }))
-    transitionFinishCallbacks.forEach(cb => cb())
-    expect(revertSpy).toHaveBeenCalledOnce()
-
-    // Scope dispose after — revert should NOT be called again (ctx is null)
-    unmountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).toHaveBeenCalledOnce()
-  })
-
-  it('reverts context immediately in onUnmounted when leaving page has no transition', async () => {
-    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
-    const { gsap } = await import('gsap')
-
-    const revertSpy = vi.fn()
-    vi.spyOn(gsap, 'context').mockReturnValue({
-      add: vi.fn((fn: () => unknown) => fn()),
-      revert: revertSpy,
-      kill: vi.fn(),
-      data: [],
-    } as unknown as gsap.Context)
-
-    useGsap(() => {})
-    mountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).not.toHaveBeenCalled()
-
-    // Route leave with no pageTransition in meta — willTransition is false, hookOnce NOT registered
-    routeLeaveCallbacks.forEach(cb => cb({}, { meta: {} }))
-    expect(revertSpy).not.toHaveBeenCalled()
-
-    // onUnmounted fires — reverts immediately (isLeavingViaRoute stayed false)
-    unmountedCallbacks.forEach(cb => cb())
-    expect(revertSpy).toHaveBeenCalledOnce()
   })
 })
 
@@ -382,12 +220,12 @@ describe('useGsap options', () => {
     mountedCallbacks.length = 0
     unmountedCallbacks.length = 0
     watchCallbacks.length = 0
+    nextTickMock.mockClear()
     vi.restoreAllMocks()
   })
 
   it('registers a watcher when dependencies option is provided', async () => {
-    const { watch } = await import('vue')
-    const { ref } = await import('vue')
+    const { watch, ref } = await import('vue')
     const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
 
     const dep = ref(0)
@@ -396,13 +234,48 @@ describe('useGsap options', () => {
     expect(watch).toHaveBeenCalledOnce()
   })
 
-  it('does not revert context on dependency update when revertOnUpdate is false', async () => {
+  it('re-runs setup after nextTick when dependencies change', async () => {
+    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
+    const { gsap } = await import('gsap')
+    const { ref } = await import('vue')
+
+    const firstRevertSpy = vi.fn()
+    const secondRevertSpy = vi.fn()
+    const contextSpy = vi.spyOn(gsap, 'context')
+      .mockReturnValueOnce({
+        add: vi.fn((fn: () => unknown) => fn()),
+        revert: firstRevertSpy,
+        kill: vi.fn(),
+        data: [],
+      } as unknown as gsap.Context)
+      .mockReturnValueOnce({
+        add: vi.fn((fn: () => unknown) => fn()),
+        revert: secondRevertSpy,
+        kill: vi.fn(),
+        data: [],
+      } as unknown as gsap.Context)
+
+    const dep = ref(0)
+    useGsap(() => {}, { dependencies: dep })
+    await flushMount()
+
+    expect(contextSpy).toHaveBeenCalledTimes(1)
+
+    await flushWatch()
+
+    expect(firstRevertSpy).toHaveBeenCalledOnce()
+    expect(nextTickMock).toHaveBeenCalledTimes(2)
+    expect(contextSpy).toHaveBeenCalledTimes(2)
+    expect(secondRevertSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not revert or re-run setup on dependency update when revertOnUpdate is false', async () => {
     const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
     const { gsap } = await import('gsap')
     const { ref } = await import('vue')
 
     const revertSpy = vi.fn()
-    vi.spyOn(gsap, 'context').mockReturnValue({
+    const contextSpy = vi.spyOn(gsap, 'context').mockReturnValue({
       add: vi.fn((fn: () => unknown) => fn()),
       revert: revertSpy,
       kill: vi.fn(),
@@ -411,11 +284,48 @@ describe('useGsap options', () => {
 
     const dep = ref(0)
     useGsap(() => {}, { dependencies: dep, revertOnUpdate: false })
-    mountedCallbacks.forEach(cb => cb())
+    await flushMount()
+    await flushWatch()
 
-    // Trigger the watch callback — revert must NOT be called
-    watchCallbacks.forEach(cb => cb())
     expect(revertSpy).not.toHaveBeenCalled()
+    expect(contextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates rapid dependency updates and keeps only the latest scheduled setup', async () => {
+    nextTickMock.mockImplementation(() => Promise.resolve())
+
+    const { useGsap } = await import('../src/runtime/composables/createGsapComposable')
+    const { gsap } = await import('gsap')
+    const { ref } = await import('vue')
+
+    const firstRevertSpy = vi.fn()
+    const secondRevertSpy = vi.fn()
+    const contextSpy = vi.spyOn(gsap, 'context')
+      .mockReturnValueOnce({
+        add: vi.fn((fn: () => unknown) => fn()),
+        revert: firstRevertSpy,
+        kill: vi.fn(),
+        data: [],
+      } as unknown as gsap.Context)
+      .mockReturnValueOnce({
+        add: vi.fn((fn: () => unknown) => fn()),
+        revert: secondRevertSpy,
+        kill: vi.fn(),
+        data: [],
+      } as unknown as gsap.Context)
+
+    const dep = ref(0)
+    useGsap(() => {}, { dependencies: dep })
+    await flushMount()
+
+    const watchCallback = watchCallbacks[0]!
+    const firstUpdate = watchCallback()
+    const secondUpdate = watchCallback()
+    await Promise.all([firstUpdate, secondUpdate])
+
+    expect(firstRevertSpy).toHaveBeenCalledOnce()
+    expect(contextSpy).toHaveBeenCalledTimes(2)
+    expect(secondRevertSpy).not.toHaveBeenCalled()
   })
 
   it('passes scope element to gsap.context when scope option is provided', async () => {
@@ -432,8 +342,8 @@ describe('useGsap options', () => {
 
     const el = {} as HTMLElement
     const scopeRef = ref<HTMLElement | null>(el)
-    useGsap(() => {}, { scope: scopeRef })
-    mountedCallbacks.forEach(cb => cb())
+    useGsap(() => {}, { scope: scopeRef, cleanupOn: 'route-leave' })
+    await flushMount()
 
     expect(contextSpy).toHaveBeenCalledWith(expect.any(Function), el)
   })

--- a/test/fixtures/with-transitions/pages/index.vue
+++ b/test/fixtures/with-transitions/pages/index.vue
@@ -12,8 +12,8 @@
 <script setup lang="ts">
 const boxRef = ref<HTMLElement | null>(null)
 
-// cleanupOn: 'route-leave' reverts GSAP before the leave transition plays,
-// preventing visual glitches when the animation conflicts with the exit animation.
+// `cleanupOn` is accepted for backward compatibility, but cleanup still happens
+// during component teardown.
 useGsap(
   () => {
     gsap.to(boxRef.value, { x: 200, duration: 1, repeat: -1, yoyo: true })


### PR DESCRIPTION
## Summary

- Removes `onBeforeRouteLeave` + `page:transition:finish` deferral logic — `onUnmounted` is sufficient since Nuxt only unmounts the leaving page after the leave transition completes
- Fixes a bug where a cancelled navigation (router guard rejecting after `onBeforeRouteLeave`) could leave the GSAP context alive indefinitely
- Adds `nextTick`-deferred setup with `setupVersion` cancellation to prevent stale setups on rapid dependency updates and unmount-before-tick races
- Drops imports: `useNuxtApp`, `appPageTransition`, `onBeforeRouteLeave`
- `cleanupOn` option remains accepted for backward compatibility but is now a true no-op

## Test plan

- [ ] `npx vitest run` — all 21 tests pass
- [ ] Playground: navigate between pages with and without transitions, verify animations play through the fade-out and restart cleanly on return
- [ ] Playground `page-transition` page: both columns clean up correctly on navigation
- [ ] Playground `no-transition` page: context reverts immediately on unmount, animation restarts on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)